### PR TITLE
deploy on tag; bump to 0.1.dev0

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,7 @@ jobs:
           retention-days: 7
 
       - name: Deploy to gh-pages
+        if: startsWith(github.ref, 'refs/tags/')
         uses: JamesIves/github-pages-deploy-action@3.7.1        
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,7 +4,7 @@ name: Style Check
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  stylecheck:
     runs-on: ubuntu-20.04
 
     steps:

--- a/pyansys_sphinx_theme/_version.py
+++ b/pyansys_sphinx_theme/_version.py
@@ -8,7 +8,7 @@ version_info = 0, 0, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 0, 'dev0'
+version_info = 0, 1, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Prepare release branch by bumping to 0.1.dev0.  Also, minor fix to ensure docs are only deployed on tags. 
