### PR TITLE
Add docstring example best practices to doc

### DIFF
--- a/doc/source/coding_style.rst
+++ b/doc/source/coding_style.rst
@@ -135,3 +135,173 @@ update any projects dependent on the API while still being treated as
 "first-class" users.  Note that due to the complexity of maintaining
 multiple "release branches" in a repository, the number of active
 release branches should be between one and three.
+
+Docstring Examples Best-Practice
+---------------------------------
+Defining docstring examples for methods and classes are extremely 
+useful. The examples give users an easy place to start when trying 
+out the API, by showing them exactly how to operate on a method or 
+class. By using ``doctest`` through ``pytest``, docstring examples can 
+also be used to perform regression testing to verify that the code is 
+executing as expected.
+
+Setting Up ``doctest``
+~~~~~~~~~~~~~~~~~~~~~~
+First, install ``pytest``:
+
+.. code::
+
+    pip install pytest
+
+Then, ``doctest`` can be run on any Python file by running:
+
+.. code::
+
+    pytest --doctest-modules file.py
+
+Here, ``doctest`` will search for any examples in the docstrings and will then
+execute them to verify that they function as written.
+
+Using ``pytest`` Fixtures
+~~~~~~~~~~~~~~~~~~~~~~~~~
+To define a set up sequence before the ``doctest`` run or before a given 
+module is tested, ``pytest`` fixtures can be used. Fixtures allow docstring 
+examples to access shared objects, so there is no need to repeat the set 
+up in each example.
+
+``pytest`` fixtures can defined in a ``conftest.py`` file next to the source 
+code. The following example shows a fixture that is run automatically for 
+each ``doctest`` session.
+
+.. code:: python
+
+    import pytest
+
+    from pyaedt import Desktop
+
+
+    @pytest.fixture(autouse=True, scope="session")
+    def start_aedt():
+        desktop = Desktop("2021.1", NG=True)
+        desktop.disable_autosave()
+
+        # Wait to run doctest on docstrings
+        yield desktop
+        desktop.force_close_desktop()
+
+Fixtures can also be defined in a separate Python file from 
+``conftest.py``. This may help keep the fixtures more organized. Fixtures 
+from other files need to be imported in the main ``conftest.py`` file. The 
+following example shows how to import fixtures defined in an 
+``icepak_fixtures.py`` file under the ``doctest_fixtures`` folder.
+
+.. code:: python
+
+    import pytest
+
+    from pyaedt import Desktop
+    from pyaedt.doctest_fixtures import *
+
+    # Import fixtures from other files
+    pytest_plugins = [
+        "pyaedt.doctest_fixtures.icepak_fixtures",
+    ]
+
+
+    @pytest.fixture(autouse=True, scope="session")
+    def start_aedt():
+        desktop = Desktop("2021.1", NG=True)
+        desktop.disable_autosave()
+
+        # Wait to run doctest on docstrings
+        yield desktop
+        desktop.force_close_desktop()
+
+The ``doctest_namespace`` fixture built in to ``doctest`` allows injecting
+items from a fixture into the context of the ``doctest`` run. To use this
+feature, the fixture needs to accept the ``doctest_namespace`` dictionary
+as an argument. Then, objects can be added to the ``doctest_namespace``
+dictionary and used directly in a docstring example.
+
+The code below shows how the ``Icepak`` object can be stored in the
+``doctest_namespace`` dictionary by adding the key ``icepak`` with the 
+``Icepak`` object as the value. 
+
+.. code:: python
+
+    import pytest
+    from pyaedt import Icepak
+
+
+    @pytest.fixture(autouse=True, scope="module")
+    def create_icepak(doctest_namespace):
+        doctest_namespace["icepak"] = Icepak(projectname="Project1", designname="IcepakDesign1")
+
+Then, the ``Icepak`` object can be used directly inside a docstring
+example, by referencing the key ``icepak``.
+
+.. code:: python
+
+    def assign_openings(self, air_faces):
+        """Assign openings to a list of faces.
+
+        Parameters
+        ----------
+        air_faces : list
+            List of face names.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object when successful or ``None`` when failed.
+
+        Examples
+        --------
+
+        Create an opening boundary for the faces of the "USB_GND" object.
+
+        >>> faces = icepak.modeler.primitives["USB_GND"].faces
+        >>> face_names = [face.id for face in faces]
+        >>> boundary = icepak.assign_openings(face_names)
+        pyaedt Info: Face List boundary_faces created
+        pyaedt Info: Opening Assigned
+
+        """
+
+Useful Features
+---------------
+
+Ellipses For Random Output
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the output of some operation in an example cannot be verified exactly,
+an ellipsis (``...``) can be used in the expected output. This allows it
+to match any substring in the actual output.
+
+.. code ::
+
+    Examples
+    --------
+
+    >>> desktop = Desktop("2021.1")
+    pyaedt Info: pyaedt v...
+    pyaedt Info: Python version ...
+
+To allow this, ``doctest`` must be run with the option set to allow ellipses.
+
+.. code ::
+
+    pytest --doctest-modules -o ELLIPSIS file.py
+
+``doctest`` Skip
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+The directive ``# doctest: +SKIP`` can be added to any line of a
+docstring example so that it is not executed. This is useful for examples
+that have really random output or that may cause problems with other tests
+if they are run during the ``doctest`` session.
+
+.. code ::
+
+    Examples
+    --------
+
+    >>> desktop = Desktop("2021.1") # doctest: +SKIP

--- a/doc/source/coding_style.rst
+++ b/doc/source/coding_style.rst
@@ -137,13 +137,18 @@ multiple "release branches" in a repository, the number of active
 release branches should be between one and three.
 
 Docstring Examples Best-Practice
----------------------------------
+--------------------------------
 Defining docstring examples for methods and classes are extremely 
 useful. The examples give users an easy place to start when trying 
 out the API, by showing them exactly how to operate on a method or 
 class. By using ``doctest`` through ``pytest``, docstring examples can 
 also be used to perform regression testing to verify that the code is 
 executing as expected.
+
+This is an important feature of maintainable documentation as examples
+must always match the API they are documenting, and any changes within
+the API without a corresponding change in the documentation will
+trigger doctest failures.
 
 Setting Up ``doctest``
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -164,10 +169,10 @@ execute them to verify that they function as written.
 
 Using ``pytest`` Fixtures
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-To define a set up sequence before the ``doctest`` run or before a given 
+To define a setup sequence before the ``doctest`` run or before a given 
 module is tested, ``pytest`` fixtures can be used. Fixtures allow docstring 
-examples to access shared objects, so there is no need to repeat the set 
-up in each example.
+examples to access shared objects, so there is no need to repeat the setup
+in each example.
 
 ``pytest`` fixtures can defined in a ``conftest.py`` file next to the source 
 code. The following example shows a fixture that is run automatically for 
@@ -293,13 +298,13 @@ To allow this, ``doctest`` must be run with the option set to allow ellipses.
     pytest --doctest-modules -o ELLIPSIS file.py
 
 ``doctest`` Skip
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 The directive ``# doctest: +SKIP`` can be added to any line of a
-docstring example so that it is not executed. This is useful for examples
-that have really random output or that may cause problems with other tests
+docstring example so that it is not executed in ``doctest-modules``. This is useful for examples
+that cannot run within ``pytest`` or have side-effects that will affect the other tests
 if they are run during the ``doctest`` session.
 
-.. code ::
+.. code :: python
 
     Examples
     --------


### PR DESCRIPTION
This PR adds to the Coding Style and Best Practices documentation. The new section describes some of the set up for doctest and how to use it with docstring examples. 