### PR TITLE
Reword deprecation warning examples

### DIFF
--- a/doc/source/coding_style.rst
+++ b/doc/source/coding_style.rst
@@ -53,13 +53,13 @@ and then using an error after a minor release or two.
             """
             # one of the following:
 
-            # raise a DeprecationWarning.  User won't have to change anything
-            warnings.warn('assignmaterial is deprecated.  Please use assign_material instead',
+            # raise a DeprecationWarning. User won't have to change anything
+            warnings.warn('assignmaterial is deprecated. Use assign_material instead.',
                           DeprecationWarning)
             self.assign_material(obj, mat)
 
             # or raise an AttributeError (could also make a custom DeprecationError)
-            raise AttributeError('assignmaterial is deprecated.  Please use assign_material instead')
+            raise AttributeError('assignmaterial is deprecated. Use assign_material instead.')
 
         def assign_material(self, obj, mat):
             """Assign a material to one or more objects.

--- a/doc/source/coding_style.rst
+++ b/doc/source/coding_style.rst
@@ -54,12 +54,12 @@ and then using an error after a minor release or two.
             # one of the following:
 
             # raise a DeprecationWarning. User won't have to change anything
-            warnings.warn('`assignmaterial` is deprecated. Use assign_material instead.',
+            warnings.warn('`assignmaterial` is deprecated. Use `assign_material` instead.',
                           DeprecationWarning)
             self.assign_material(obj, mat)
 
             # or raise an AttributeError (could also make a custom DeprecationError)
-            raise AttributeError('`assignmaterial` is deprecated. Use assign_material instead.')
+            raise AttributeError('`assignmaterial` is deprecated. Use `assign_material` instead.')
 
         def assign_material(self, obj, mat):
             """Assign a material to one or more objects.

--- a/doc/source/coding_style.rst
+++ b/doc/source/coding_style.rst
@@ -64,6 +64,7 @@ and then using an error after a minor release or two.
         def assign_material(self, obj, mat):
             """Assign a material to one or more objects.
             ...
+            """
 
 
 If a method is outright removed, there's no reason to provide a link

--- a/doc/source/coding_style.rst
+++ b/doc/source/coding_style.rst
@@ -54,12 +54,12 @@ and then using an error after a minor release or two.
             # one of the following:
 
             # raise a DeprecationWarning. User won't have to change anything
-            warnings.warn('assignmaterial is deprecated. Use assign_material instead.',
+            warnings.warn('`assignmaterial` is deprecated. Use assign_material instead.',
                           DeprecationWarning)
             self.assign_material(obj, mat)
 
             # or raise an AttributeError (could also make a custom DeprecationError)
-            raise AttributeError('assignmaterial is deprecated. Use assign_material instead.')
+            raise AttributeError('`assignmaterial` is deprecated. Use assign_material instead.')
 
         def assign_material(self, obj, mat):
             """Assign a material to one or more objects.


### PR DESCRIPTION
Remove use of "Please" and the extra space in deprecation warning example, following Kathy's edits to these deprecation warnings in use in pyaedt.