### PR TITLE
Improve API doc empty-space formatting

### DIFF
--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -166,3 +166,16 @@
 i.fa-github-square:before {
     color: #ffffff !important;
 }
+
+/* Increase empty-space around classes, methods, properties, etc. that are descendants
+ of other items */
+dl.class dl.py {
+    margin-top: 2.5em;
+    margin-bottom: 2.5em;
+}
+
+/* Reduce empty-space around Notes and Examples headings */
+p.rubric {
+    margin-top: 0.75em;
+    margin-bottom: 0.75em;
+}


### PR DESCRIPTION
Adds some custom styling to improve the grouping and readability of generated API docs. Side by side comparison (current on left, proposed on right):

![image](https://user-images.githubusercontent.com/6451062/145616011-c0a9f2a0-aaf7-41a0-82ea-0809d8e93456.png)

There's less space between 'Parameters' and 'Examples', and more space between 'Examples' and the methods. This helps the examples feel more like they belong to the class itself, as opposed to the method below.

I'm not a CSS expert, but I think the selectors are appropriate and seem to align with how the styling is written in the base sphinx package. These changes have been tested on the example API Documentation in this package, and on the as-yet-unreleased grantami-bomanalytics package.