### PR TITLE
Added style to table representation

### DIFF
--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -218,6 +218,56 @@ tr:nth-child(even){
 background-color: rgb(255, 183, 27, 0.15); 
 }
 
+/*
+###############
+   longtable 
+###############
+
+Use as:
+
+.. table:: 
+  :class: table-centered
+
+  +---------------------------+-------------------+
+  |                           | MAPDL Command     |
+  +===========================+===================+
+  | **GUI commands**          | * ``*ASK``        |
+  |                           +-------------------+
+  |   ...
+  |   ...
+
+
+*/
+table.table-centered {
+  width:100%;
+  max-width: 100%; 
+  border-spacing: 0;
+  border-collapse: collapse;
+  overflow: hidden;
+  vertical-align: middle;
+
+  /* Disabling scroll bars */
+  overflow-y: scroll;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* Internet Explorer 10+ */
+  }
+
+.table-centered tr { 
+  background-color: white;
+}
+
+.table-centered th {
+  background-color: rgb(255, 183, 27, 0.55);
+}
+
+.table-centered tr:nth-child(odd){ 
+  background-color: white;
+}
+
+.table-centered tr:nth-child(even){
+background-color: rgb(255, 183, 27, 0.15); 
+}
+
 
 /*
 ###############
@@ -230,26 +280,58 @@ table.longtable tr:hover td {
 }
 
 /*
-###############
-   DataFrame 
-###############
-Not sure why the odd columns (white) are rendered gray.
+#########################
+   longtable-centered
+#########################
+
+Use as:
+
+
+.. table:: 
+  :class: longtable-centered
+
+  +---------------------------+-------------------+
+  |                           | MAPDL Command     |
+  +===========================+===================+
+  | **GUI commands**          | * ``*ASK``        |
+  |                           +-------------------+
+  |   ...
+  |   ...
+
 */
 
-.dataframe tr{ 
-    background-color: white;
-  }
-
-.dataframe tr:nth-child(odd){ 
-    background-color: white;  
-  }
-
-.dataframe tr:nth-child(even){
-  background-color: rgb(255, 183, 27, 0.15);
+table.longtable-centered tr:hover td {
+  background-color: rgb(255, 183, 27, 0.6);
+  text-align: center;
 }
 
-.dataframe tr:hover td {
+/*
+#########################
+   DataFrame-centered
+#########################
+Not sure why the odd columns (white) are rendered gray.
+
+I do not think we will be able to call this class.
+*/
+
+.dataframe-centered tr{ 
+    background-color: white;
+    text-align: center;
+  }
+
+.dataframe-centered tr:nth-child(odd){ 
+    background-color: white;  
+    text-align: center;
+  }
+
+.dataframe-centered tr:nth-child(even){
+  background-color: rgb(255, 183, 27, 0.15);
+  text-align: center;
+}
+
+.dataframe-centered tr:hover td {
   background-color: rgb(255, 183, 27, 0.6);
+  text-align: center;
 }
 
 
@@ -270,5 +352,7 @@ Not sure why the odd columns (white) are rendered gray.
 .autosummary tr:nth-child(even){
   background-color: white;
 }
+
+
 
 

--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -179,34 +179,84 @@ p.rubric {
     margin-top: 0.75em;
     margin-bottom: 0.75em;
 }
+
+
 /*
-Table style for the DataFrame representation
+#############
 */
 table {
-  border-collapse: collapse;
-  width: 100%;
-}
+        width:100%;
+        max-width: 100%; 
+        border-spacing: 0;
+        border-collapse: collapse;
+        overflow: hidden;
+        z-index: 1;
+        font-size: 16px;
+        text-align: center;
+        
+        /* Disabling scroll bars */
+        overflow-y: scroll;
+        scrollbar-width: none; /* Firefox */
+        -ms-overflow-style: none;  /* Internet Explorer 10+ */
+        }
 
-th {
-  text-align: center;
-  padding: 8px;
-  font-size: 16px;
-}
 
-td {
-  text-align: left;
-  padding: 8px;
-  font-size: 16px;
-}
+ /* Disabling scroll bars */
+table::-webkit-scrollbar { /* WebKit */
+    width: 0;
+    height: 0;
+}    
 
-td:hover {
-  background-color: #ffb71b;
-}
+/* Headers and data cells format */
+    td, th {
+        cursor: pointer;
+        padding: 10px;
+        position: relative;
+        background-color: white;
+        text-align: center;
+        font-size: 16px;
+    }
+    
 
-tr:nth-child(even){background-color: #ffdf99}
+/* Highlighting columns and rows */
+    td:hover::before { 
+        background-color: rgb(200, 146, 17, 0.15);
+        content: '\00a0';  
+        height: 100%;
+        left: -5000px;
+        position: absolute;  
+        top: 0;
+        width: 10000px;    
+        z-index: 10;        
+    }
+    
+    td:hover::after { 
+        background-color: rgba(200, 146, 17, 0.15);
+        content: '\00a0';   
+        height: 10000px;   
+        left: 0;
+        position: absolute;  
+        top: -5000px;
+        width: 100%;
+        z-index: 10; 
+        text-shadow: 1px 0px 2px #000;
+    }
 
-th {
-  text-align: center;
-  background-color: #ffb71b;
-  color: black;
+    /* Highlighting headers */
+    th {
+      text-align: center;
+      background-color: rgb(255, 183, 27, 0.55);
+    }
+
+    /* This should highlight the even and odd rows differently. */
+     tr:nth-child(odd){
+       background-color: rgb(255, 183, 27, 0.25);    
+       z-index: 0;
+      text-align: center;
+      }
+
+ tr:nth-child(even){
+       background-color: rgb(255, 183, 27, 0.25);    
+        z-index: 0;  
+      text-align: center;
 }

--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -179,3 +179,34 @@ p.rubric {
     margin-top: 0.75em;
     margin-bottom: 0.75em;
 }
+/*
+Table style for the DataFrame representation
+*/
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th {
+  text-align: center;
+  padding: 8px;
+  font-size: 16px;
+}
+
+td {
+  text-align: left;
+  padding: 8px;
+  font-size: 16px;
+}
+
+td:hover {
+  background-color: #ffb71b;
+}
+
+tr:nth-child(even){background-color: #ffdf99}
+
+th {
+  text-align: center;
+  background-color: #ffb71b;
+  color: black;
+}

--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -194,7 +194,6 @@ table {
   border-spacing: 0;
   border-collapse: collapse;
   overflow: hidden;
-  text-align: center;
   vertical-align: middle;
 
   /* Disabling scroll bars */
@@ -204,23 +203,19 @@ table {
   }
 
 tr { 
-  background-color: white;  
-  text-align: center;
+  background-color: white;
 }
 
 th {
-  text-align: center;
   background-color: rgb(255, 183, 27, 0.55);
 }
 
 tr:nth-child(odd){ 
-  background-color: white;  
-  text-align: center;
+  background-color: white;
 }
 
 tr:nth-child(even){
 background-color: rgb(255, 183, 27, 0.15); 
-text-align: center;
 }
 
 
@@ -242,8 +237,7 @@ Not sure why the odd columns (white) are rendered gray.
 */
 
 .dataframe tr{ 
-    background-color: white;  
-    text-align: center;
+    background-color: white;
   }
 
 .dataframe tr:nth-child(odd){ 
@@ -265,18 +259,16 @@ Not sure why the odd columns (white) are rendered gray.
    Autosummary 
 ###############
 */
-.autosummary {
+/* .autosummary {
         text-align: left;
-        }
+        } */
 
 .autosummary  tr:nth-child(odd){ 
-    background-color: white;  
-    text-align: center;
+    background-color: white;
   }
 
 .autosummary tr:nth-child(even){
-  background-color: white;  
-  text-align: center;
+  background-color: white;
 }
 
 

--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -219,9 +219,11 @@ background-color: rgb(255, 183, 27, 0.15);
 }
 
 /*
-###############
-   longtable 
-###############
+#####################
+   Table-centered 
+#####################
+Same as table but with horizontally centered text.
+
 
 Use as:
 
@@ -245,6 +247,7 @@ table.table-centered {
   border-collapse: collapse;
   overflow: hidden;
   vertical-align: middle;
+  text-align: center;
 
   /* Disabling scroll bars */
   overflow-y: scroll;
@@ -254,18 +257,22 @@ table.table-centered {
 
 .table-centered tr { 
   background-color: white;
+  text-align: center;
 }
 
 .table-centered th {
   background-color: rgb(255, 183, 27, 0.55);
+  text-align: center;
 }
 
 .table-centered tr:nth-child(odd){ 
+  text-align: center;
   background-color: white;
 }
 
 .table-centered tr:nth-child(even){
-background-color: rgb(255, 183, 27, 0.15); 
+  background-color: rgb(255, 183, 27, 0.15); 
+  text-align: center;
 }
 
 
@@ -300,10 +307,56 @@ Use as:
 
 */
 
+table.longtable-centered {
+  text-align: center;
+  }
+
+.longtable-centered tr { 
+  text-align: center;
+}
+
+.longtable-centered th {
+  text-align: center;
+}
+
+.longtable-centered tr:nth-child(odd){ 
+  text-align: center;
+}
+
+.longtable-centered tr:nth-child(even){
+  text-align: center;
+}
+
 table.longtable-centered tr:hover td {
   background-color: rgb(255, 183, 27, 0.6);
   text-align: center;
 }
+
+/*
+##############
+   DataFrame
+##############
+Not sure why the odd columns (white) are rendered gray.
+
+I do not think we will be able to call this class.
+*/
+
+.dataframe tr{ 
+    background-color: white;
+  }
+
+.dataframe tr:nth-child(odd){ 
+    background-color: white !important;
+  }
+
+.dataframe tr:nth-child(even){
+  background-color: rgb(255, 183, 27, 0.15);
+}
+
+.dataframe tr:hover td {
+  background-color: rgb(255, 183, 27, 0.6);
+}
+
 
 /*
 #########################
@@ -320,7 +373,7 @@ I do not think we will be able to call this class.
   }
 
 .dataframe-centered tr:nth-child(odd){ 
-    background-color: white;  
+    background-color: white !important;  
     text-align: center;
   }
 
@@ -332,6 +385,10 @@ I do not think we will be able to call this class.
 .dataframe-centered tr:hover td {
   background-color: rgb(255, 183, 27, 0.6);
   text-align: center;
+}
+
+.dataframe thead th {
+    text-align: center;
 }
 
 

--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -181,82 +181,102 @@ p.rubric {
 }
 
 
+
 /*
-#############
+###############
+   table 
+###############
 */
+
 table {
-        width:100%;
-        max-width: 100%; 
-        border-spacing: 0;
-        border-collapse: collapse;
-        overflow: hidden;
-        z-index: 1;
-        font-size: 16px;
-        text-align: center;
-        
-        /* Disabling scroll bars */
-        overflow-y: scroll;
-        scrollbar-width: none; /* Firefox */
-        -ms-overflow-style: none;  /* Internet Explorer 10+ */
+  width:100%;
+  max-width: 100%; 
+  border-spacing: 0;
+  border-collapse: collapse;
+  overflow: hidden;
+  text-align: center;
+  vertical-align: middle;
+
+  /* Disabling scroll bars */
+  overflow-y: scroll;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* Internet Explorer 10+ */
+  }
+
+tr { 
+  background-color: white;  
+  text-align: center;
+}
+
+th {
+  text-align: center;
+  background-color: rgb(255, 183, 27, 0.55);
+}
+
+tr:nth-child(odd){ 
+  background-color: white;  
+  text-align: center;
+}
+
+tr:nth-child(even){
+background-color: rgb(255, 183, 27, 0.15); 
+text-align: center;
+}
+
+
+/*
+###############
+   longtable 
+###############
+*/
+
+table.longtable tr:hover td {
+  background-color: rgb(255, 183, 27, 0.6);
+}
+
+/*
+###############
+   DataFrame 
+###############
+Not sure why the odd columns (white) are rendered gray.
+*/
+
+.dataframe tr{ 
+    background-color: white;  
+    text-align: center;
+  }
+
+.dataframe tr:nth-child(odd){ 
+    background-color: white;  
+  }
+
+.dataframe tr:nth-child(even){
+  background-color: rgb(255, 183, 27, 0.15);
+}
+
+.dataframe tr:hover td {
+  background-color: rgb(255, 183, 27, 0.6);
+}
+
+
+
+/*
+###############
+   Autosummary 
+###############
+*/
+.autosummary {
+        text-align: left;
         }
 
+.autosummary  tr:nth-child(odd){ 
+    background-color: white;  
+    text-align: center;
+  }
 
- /* Disabling scroll bars */
-table::-webkit-scrollbar { /* WebKit */
-    width: 0;
-    height: 0;
-}    
-
-/* Headers and data cells format */
-    td, th {
-        cursor: pointer;
-        padding: 10px;
-        position: relative;
-        background-color: white;
-        text-align: center;
-        font-size: 16px;
-    }
-    
-
-/* Highlighting columns and rows */
-    td:hover::before { 
-        background-color: rgb(200, 146, 17, 0.15);
-        content: '\00a0';  
-        height: 100%;
-        left: -5000px;
-        position: absolute;  
-        top: 0;
-        width: 10000px;    
-        z-index: 10;        
-    }
-    
-    td:hover::after { 
-        background-color: rgba(200, 146, 17, 0.15);
-        content: '\00a0';   
-        height: 10000px;   
-        left: 0;
-        position: absolute;  
-        top: -5000px;
-        width: 100%;
-        z-index: 10; 
-        text-shadow: 1px 0px 2px #000;
-    }
-
-    /* Highlighting headers */
-    th {
-      text-align: center;
-      background-color: rgb(255, 183, 27, 0.55);
-    }
-
-    /* This should highlight the even and odd rows differently. */
-     tr:nth-child(odd){
-       background-color: rgb(255, 183, 27, 0.25);    
-       z-index: 0;
-      text-align: center;
-      }
-
- tr:nth-child(even){
-       background-color: rgb(255, 183, 27, 0.25);    
-        z-index: 0;  
-      text-align: center;
+.autosummary tr:nth-child(even){
+  background-color: white;  
+  text-align: center;
 }
+
+


### PR DESCRIPTION
Hi there

Since we would like to use Pandas DataFrame to present data in PyMAPDL documentation, I thought we might as well include the style in the Pyansys Theme.

The proposal is shown as this:

![image](https://user-images.githubusercontent.com/28149841/150509549-f6ebf9cb-5515-4f07-a9ea-d892b9a2f8e5.png)

I'm happy to do any changes you might propose. I just tried the colors align with Ansys color theme.