### PR TITLE
Rethinking code style

### DIFF
--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -146,7 +146,7 @@
     color: #C89211;
     font-family: 'Inconsolata';
     font-weight: bold;
-    font-size: 15px;
+    font-size: 15.5px;
 }
 
 .sig-prename {

--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -145,6 +145,7 @@
     color: #C89211;
     font-family: "Source Code Pro", "Courier New", monospace;
     font-weight: bold;
+    font-size: 16px;
 }
 
 .sig-prename {

--- a/pyansys_sphinx_theme/static/css/theme.css
+++ b/pyansys_sphinx_theme/static/css/theme.css
@@ -1,5 +1,7 @@
 /* Provided by the Sphinx base theme template at build time */
 @import "../basic.css";
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@600&display=swap');
+
 
 @font-face {
     font-family: "Source Sans Pro Light";
@@ -10,7 +12,6 @@
     font-family: "Source Sans Pro";
     src: url(../fonts/SourceSansPro-Regular.ttf);
 }
-
 
 :root {
   /* Ansys colors */
@@ -143,9 +144,9 @@
 
 .docutils {
     color: #C89211;
-    font-family: "Source Code Pro", "Courier New", monospace;
+    font-family: 'Inconsolata';
     font-weight: bold;
-    font-size: 16px;
+    font-size: 15px;
 }
 
 .sig-prename {
@@ -155,7 +156,7 @@
 
 .sig-name.descname {
     color: #C89211;
-    /* font-family: 'Source Sans Pro', sans-serif; */
+    /* font-family: '   Source Sans Pro', sans-serif; */
 }
 
 .sig-name {


### PR DESCRIPTION
I'm not super happy about the readability of the text rendered as code:

![image](https://user-images.githubusercontent.com/28149841/150781028-08e5a6bc-f68a-4b95-ab7d-50afbe5c3672.png)


And some people (@RomanIlchenko1308 ) have already pointed out that the size looks smaller than the rest of the body text.

Quick fix is to increase the font-size a bit (to 15.5px) so we can improve readability and visual impact.

![image](https://user-images.githubusercontent.com/28149841/150781490-9e6ac7d2-e9b0-4eea-9583-46d1f1404cfc.png)

However, I'm partial to change the font altogether. I personally like ``Roboto condensed Light`` [Link]  (size: normal (15px))(https://fonts.google.com/specimen/Roboto+Condensed?preview.text=package,%20ansys-mapdl-core,%20pro&preview.text_type=custom):

![image](https://user-images.githubusercontent.com/28149841/150782291-c1850be5-5273-4114-9c34-1846f2ba494f.png)

Or even better ``consolas`` (size: normal (15px)):

![image](https://user-images.githubusercontent.com/28149841/150782402-ae734c64-86ba-4b1e-845b-ac999346c66e.png)
