### PR TITLE
Allow users to show or hide havbar icons

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -95,3 +95,57 @@ the title of the ``index.rst`` page. For example:
 If you want to use the version number in
 the ``index.rst`` title, use ``|version|`` to include the package version
 number.
+
+
+Custom Icons
+------------
+
+This theme allows you to have a huge control over the icons displayed in the
+navigation bar.
+
+
+Adding New Icons
+----------------
+
+To add a new icon you will need to specify its ``name``, the associated ``URL``
+and the ``icon`` and ``type``. As an example, consider the following source code
+which adds an icon for sending an email:
+
+.. code-block:: python
+
+   html_theme_options = {
+    "icon_links": [dict(name="Mail", url="mailto:me", icon="fas fa-envelope")]
+    ...
+   }
+
+For more information about custom icons, refer to `Configure icon links
+<https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/configuring.html?highlight=icons#configure-icon-links>`_
+section in `PyData Sphinx Theme Docs
+<https://pydata-sphinx-theme.readthedocs.io/en/stable>`_. Regarding
+``FontAwesome`` usage, please visit `Find and Add Icons
+<https://fontawesome.com/v5/docs/web/setup/get-started>`_.
+
+
+Hiding Icons
+------------
+
+You can also select which icons should be displayed or not. To do so, add their
+names to the ``hidden_icons`` list:
+
+.. code-block:: python
+
+   html_theme_options = {
+       "hidden_icons": ["GitHub"],
+       ...
+   }
+
+
+If you want to hide all icons, you can also use the ``show_icons`` boolean
+variable:
+
+.. code-block:: python
+
+   html_theme_options = {
+       "show_icons": False,
+       ...
+   }

--- a/src/pyansys_sphinx_theme/docs-navbar.html
+++ b/src/pyansys_sphinx_theme/docs-navbar.html
@@ -28,6 +28,7 @@
       {% endfor %}
     </div>
 
+    {% if theme_show_icons %}
     <div id="navbar-end">
       {% for navbar_item in theme_navbar_end %}
       <div class="navbar-end-item">
@@ -35,5 +36,6 @@
       </div>
       {% endfor %}
     </div>
+    {% endif %}
   </div>
 </div>

--- a/src/pyansys_sphinx_theme/icon-links.html
+++ b/src/pyansys_sphinx_theme/icon-links.html
@@ -1,0 +1,27 @@
+{%- macro icon_link_nav_item(url, icon, name, type) -%}
+  {%- if (url | length > 2) and name not in theme_hidden_icons %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url }}" rel="noopener" target="_blank" title="{{ _(name) }}">
+            {%- if type == "fontawesome" -%}
+            <span><i class="{{ icon }}"></i></span>
+            <label class="sr-only">{{ _(name) }}</label>
+            {%- elif type == "local" -%}
+            <img src="{{ pathto(icon, 1) }}" class="icon-link-image" alt="{{ _(name) }}"/>
+            {%- elif type == "url" -%}
+            <img src="{{ icon }}" class="icon-link-image" alt="{{ _(name) }}"/>
+            {%- else %}
+            <span>Incorrectly configured icon link. Type must be `fontawesome`, `url` or `local`.</span>
+            {%- endif -%}
+          </a>
+        </li>
+  {%- endif -%}
+{%- endmacro -%}
+
+      <ul id="navbar-icon-links" class="navbar-nav" aria-label="{{ _(theme_icon_links_label) }}">
+        {%- block icon_link_shortcuts -%}
+        {{ icon_link_nav_item(theme_github_url, "fab fa-github-square", "GitHub", "fontawesome") -}}
+        {% endblock -%}
+        {%- for icon_link in theme_icon_links -%}
+        {{ icon_link_nav_item(icon_link["url"], icon_link["icon"], icon_link["name"], icon_link.get("type", "fontawesome")) -}}
+        {%- endfor %}
+      </ul>

--- a/src/pyansys_sphinx_theme/theme.conf
+++ b/src/pyansys_sphinx_theme/theme.conf
@@ -6,4 +6,6 @@ pygments_style = friendly
 github_url = https://github.com/pyansys
 logo_link = https://docs.pyansys.com/
 show_breadcrumbs = True
+show_icons = True
+hidden_icons =
 additional_breadcrumbs =


### PR DESCRIPTION
Resolves #38 by adding:

- [x] A boolean variable named `show_icons` to display or hide navbar icons.
- [x] A list variable named `hidden_icons` to select by name which individual icons may be hidden.

These changes are not really needed but this would imply having the following in our `conf.py` in order to hide an icon:

```python
html_theme_options = {
    "github_url": "",
    ...
}
```

With this PR, we get a better syntax:

```python
html_theme_options = {
    "show_icons": False,
}
```

Also, we can better control individual icon display by name:

```python
html_theme_options = dict(
    icon_links = [dict(name="...", url="...", icon="..."), ]
    hidden_icons = ["GitHub"],
)
