### PR TITLE
disable checking main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,6 @@ repos:
   hooks:
   - id: check-merge-conflict
   - id: debug-statements
-  - id: no-commit-to-branch
-    args: [--branch, main]
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema


### PR DESCRIPTION
Don't check if you're merging main on github because github merges on main.

Pinging @jorgepiloto for visibility.