### PR TITLE
FIX: remove codecov shield

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 PyAnsys Sphinx Theme
 ====================
-|pyansys| |python| |pypi| |GH-CI| |codecov| |MIT| |black|
+|pyansys| |python| |pypi| |GH-CI| |MIT| |black|
 
 .. |pyansys| image:: https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
    :target: https://docs.pyansys.com/
@@ -13,10 +13,6 @@ PyAnsys Sphinx Theme
 .. |pypi| image:: https://img.shields.io/pypi/v/ansys-templates.svg?logo=python&logoColor=white
    :target: https://pypi.org/project/pyansys-sphinx-theme
    :alt: PyPI
-
-.. |codecov| image:: https://codecov.io/gh/pyansys/pyansys-sphinx-theme/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/pyansys/pyansys-sphinx-theme
-   :alt: Codecov
 
 .. |GH-CI| image:: https://github.com/pyansys/pyansys-sphinx-theme/actions/workflows/ci_cd.yml/badge.svg
    :target: https://github.com/pyansys/pyansys-sphinx-theme/actions/workflows/ci_cd.yml


### PR DESCRIPTION
Temorarily removing the codecov shield. Linking this to #41 to not forget about restoring it once we implement tests.